### PR TITLE
 Frontend: Menu component fix #132 

### DIFF
--- a/src/client/components/Menu/Menu.component.js
+++ b/src/client/components/Menu/Menu.component.js
@@ -6,7 +6,7 @@ export default function Menu() {
   return (
     <div className="menu">
       <ul className="menu-list">
-        <MenuItem name="Plants" link="/plants" />
+        <MenuItem name="Plants" link="/" />
         <MenuItem name="Special Offers" link="/special-offers" />
         <MenuItem name="About" link="/about-us" />
         <MenuItem name="Contact" link="/contact-us" />


### PR DESCRIPTION
# Description
Fixed the Menu component so when the user clicks on "plants" it redirects them to the Landing Page

Fixes # (issue)
https://github.com/HackYourFuture-CPH/fp-class19/issues/132

# How to test?
Terminal:  npm run dev  when the site loads click on the Menu / Plants
If it leads back to the Landing Page it works as intended.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
