### PR TITLE
fix orders/order_table

### DIFF
--- a/src/server/migrations/20220215204621_create_orders_table.js
+++ b/src/server/migrations/20220215204621_create_orders_table.js
@@ -3,7 +3,7 @@ exports.up = function (knex) {
     .createTable('orders', (table) => {
       table.increments('id').unsigned().primary();
 
-      table.integer('user_id').notNullable();
+      table.integer('user_id').notNullable().unsigned().references('users.id');
       table
         .enu('status', ['NEW', 'INPROGRESS', 'COMPLETED', 'CANCELLED'])
         .notNullable();

--- a/src/server/migrations/20220215204708_create_order_items_table.js
+++ b/src/server/migrations/20220215204708_create_order_items_table.js
@@ -1,9 +1,11 @@
 exports.up = function (knex) {
   return knex.schema.createTable('order_items', (table) => {
-    table.increments();
-    //  table.integer('order_id').notNullable().references("id").inTable("orders").onDelete("CASCADE");
-    table.integer('order_id').notNullable();
-    table.integer('product_id').notNullable();
+    table.integer('order_id').notNullable().unsigned().references('orders.id');
+    table
+      .integer('product_id')
+      .notNullable()
+      .unsigned()
+      .references('products.id');
     table.integer('quantity').notNullable();
   });
 };


### PR DESCRIPTION
# Description

This PR is about adding timestamps with table names and adding foreign key constraints in orders and order_item table.So I created new files.

Fixes # 148

# How to test?

Please provide a short summary how your changes can be tested?

1.please delete both tables(orders,order_item) from knex_migrations(Run:  delete from knex_migrations where id=what is there in your machine)
2.drop both tables
3.run-npm run db:setup

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
