### PR TITLE
Get product by id: response status codes fixed

### DIFF
--- a/src/server/api/controllers/products.controller.js
+++ b/src/server/api/controllers/products.controller.js
@@ -1,6 +1,5 @@
 const knex = require('../../config/db');
 const HttpError = require('../lib/utils/http-error');
-// const moment = require('moment-timezone');
 
 const getProducts = async(req) => {
     let { limit, offset, sortKey, sortOrder } = req.query;
@@ -60,41 +59,42 @@ const getDiscountProducts = async() => knex('products')
     )
     .where('products.is_on_discount', '=', '1');
 
-const getProductById = async(prod_id) => {
-    const id = parseInt(prod_id, 10);
-    if (isNaN(prod_id) || id < 1) {
+const getProductById = async(product_id) => {
+    const NUMBER_REGEXP = /^\d+$/g;
+    const id = parseInt(product_id, 10);
+    if (typeof product_id === 'string' && !product_id.match(NUMBER_REGEXP)) {
         throw new HttpError('Bad request, Invalid id', 400);
-    } else {
-        try {
-            const product = await knex('products')
-                .select(
-                    'id',
-                    'name',
-                    'price',
-                    'color',
-                    'size',
-                    'is_available',
-                    'stock_amount',
-                    'is_on_discount',
-                    'discount_percent',
-                    'picture',
-                )
-                .where({ id });
-            if (product.length === 0) {
-                throw new HttpError(`Product with id ${id} doesn't exist`,
-                    404);
-            } else {
-                return product;
-            }
-
-        } catch (error) {
-            if (error instanceof HttpError) {
-                throw error;
-            }
-
-            throw new HttpError('Unexpected error', 500);
-        }
     }
+    try {
+        const product = await knex('products')
+            .select(
+                'id',
+                'name',
+                'price',
+                'color',
+                'size',
+                'is_available',
+                'stock_amount',
+                'is_on_discount',
+                'discount_percent',
+                'picture',
+            )
+            .where({ id });
+        if (product.length === 0) {
+            throw new HttpError(`Product with id ${id} doesn't exist`,
+                404);
+        }
+        return product[0];
+
+
+    } catch (error) {
+        if (error instanceof HttpError) {
+            throw error;
+        }
+
+        throw new HttpError('Unexpected error', 500);
+    }
+
 };
 
 module.exports = {

--- a/src/server/api/controllers/products.controller.js
+++ b/src/server/api/controllers/products.controller.js
@@ -91,8 +91,6 @@ const getProductById = async(prod_id) => {
             if (error instanceof HttpError) {
                 throw error;
             }
-
-            throw new HttpError('Unexpected error', 500);
         }
     }
 };

--- a/src/server/api/controllers/products.controller.js
+++ b/src/server/api/controllers/products.controller.js
@@ -2,68 +2,47 @@ const knex = require('../../config/db');
 const HttpError = require('../lib/utils/http-error');
 // const moment = require('moment-timezone');
 
-const getProducts = async (req) => {
-  let { limit, offset, sortKey, sortOrder } = req.query;
-  const allowedSortKeys = new Set(['name', 'price']);
-  const allowedSortOrders = new Set(['asc', 'desc']);
+const getProducts = async(req) => {
+    let { limit, offset, sortKey, sortOrder } = req.query;
+    const allowedSortKeys = new Set(['name', 'price']);
+    const allowedSortOrders = new Set(['asc', 'desc']);
 
-  limit = limit || 10;
+    limit = limit || 10;
 
-  offset = offset || 0;
+    offset = offset || 0;
 
-  sortKey = sortKey || 'name';
+    sortKey = sortKey || 'name';
 
-  sortOrder = sortOrder || 'asc';
+    sortOrder = sortOrder || 'asc';
 
-  console.log(sortKey, allowedSortKeys.has(sortKey));
+    console.log(sortKey, allowedSortKeys.has(sortKey));
 
-  const invalidParams =
-    isNaN(limit) ||
-    limit <= 0 ||
-    isNaN(offset) ||
-    offset < 0 ||
-    !allowedSortKeys.has(sortKey) ||
-    !allowedSortOrders.has(sortOrder);
+    const invalidParams =
+        isNaN(limit) ||
+        limit <= 0 ||
+        isNaN(offset) ||
+        offset < 0 ||
+        !allowedSortKeys.has(sortKey) ||
+        !allowedSortOrders.has(sortOrder);
 
-  if (invalidParams) {
-    throw new HttpError('Type or value of parameters is incorrect', 400);
-  }
+    if (invalidParams) {
+        throw new HttpError('Type or value of parameters is incorrect', 400);
+    }
 
-  try {
-    const products = knex('products')
-      .limit(limit)
-      .offset(offset)
-      .orderBy(sortKey, sortOrder);
+    try {
+        const products = knex('products')
+            .limit(limit)
+            .offset(offset)
+            .orderBy(sortKey, sortOrder);
 
-    return products;
-  } catch (error) {
-    return error.message;
-  }
+        return products;
+    } catch (error) {
+        return error.message;
+    }
 };
 
-const getDiscountProducts = async () => knex('products')
+const getDiscountProducts = async() => knex('products')
     .select(
-      'id',
-      'name',
-      'price',
-      'color',
-      'size',
-      'is_available',
-      'stock_amount',
-      'is_on_discount',
-      'discount_percent',
-      'picture',
-    )
-    .where('products.is_on_discount', '=', '1');
-
-const getProductById = async (id) => {
-  if (!id) {
-    throw new HttpError('Id should be a number', 400);
-  }
-
-  try {
-    const products = await knex('products')
-      .select(
         'id',
         'name',
         'price',
@@ -74,19 +53,48 @@ const getProductById = async (id) => {
         'is_on_discount',
         'discount_percent',
         'picture',
-      )
-      .where({ id });
-    if (products.length === 0) {
-      throw new Error(`incorrect entry with the id of ${id}`, 404);
+    )
+    .where('products.is_on_discount', '=', '1');
+
+const getProductById = async(prod_id) => {
+    const id = parseInt(prod_id, 10);
+    if (isNaN(prod_id) || id < 1) {
+        throw new HttpError('Bad request, Invalid id', 400);
+    } else {
+        try {
+            const product = await knex('products')
+                .select(
+                    'id',
+                    'name',
+                    'price',
+                    'color',
+                    'size',
+                    'is_available',
+                    'stock_amount',
+                    'is_on_discount',
+                    'discount_percent',
+                    'picture',
+                )
+                .where({ id });
+            if (product.length === 0) {
+                throw new HttpError(`Product with id ${id} doesn't exist`,
+                    404);
+            } else {
+                return product;
+            }
+
+        } catch (error) {
+            if (error instanceof HttpError) {
+                throw error;
+            }
+
+            throw new HttpError('Unexpected error', 500);
+        }
     }
-    return products;
-  } catch (error) {
-    return error.message;
-  }
 };
 
 module.exports = {
-  getProducts,
-  getDiscountProducts,
-  getProductById,
+    getProducts,
+    getDiscountProducts,
+    getProductById,
 };

--- a/src/server/api/controllers/products.controller.js
+++ b/src/server/api/controllers/products.controller.js
@@ -91,6 +91,8 @@ const getProductById = async(prod_id) => {
             if (error instanceof HttpError) {
                 throw error;
             }
+
+            throw new HttpError('Unexpected error', 500);
         }
     }
 };


### PR DESCRIPTION
# Description

This PR is updated the endpoint get/products/:id respond with correct response message and status code.

Fixes # (191)

# How to test?

Pull the branch, run: npm run dev
Check on the swagger.
For ex: id =5, Status code:200 and response: product with 5
            id =ab, Status code:400 and response: invalid id
            id =4ab/ab4, Status code:400 and response: invalid id
            id =567, Status code:404 and response: product with id 567 doesn't exist.
            status code:500 for errors of server(if) 

# Checklist

- [ ✔] I have performed a self-review of my code
- [✔ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [✔ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [✔ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ✔] This PR is ready to be merged and not breaking any other functionality
