### PR TITLE
Frontend: Fix ProductPreview Component #226 

### DIFF
--- a/src/client/components/ProductPreview/ProductPreview.component.js
+++ b/src/client/components/ProductPreview/ProductPreview.component.js
@@ -8,35 +8,47 @@ export default function ProductPreview({
   quantityCount,
   setQuantityCount,
 }) {
+  const MIN_QUANTITY = 1;
+  const MAX_QUANTITY = 99;
+
   function decreamentQuantityCount() {
-    setQuantityCount((prevCount) => prevCount - 1);
+    if (quantityCount <= MIN_QUANTITY) {
+      return quantityCount;
+    }
+    setQuantityCount(quantityCount - 1);
   }
 
   function increamentQuantityCount() {
-    setQuantityCount((prevCount) => prevCount + 1);
+    if (quantityCount >= MAX_QUANTITY) {
+      return quantityCount;
+    }
+    setQuantityCount(quantityCount + 1);
   }
 
   function handleQuantityCountChange(e) {
     e.preventDefault();
+    if (e.target.value <= MIN_QUANTITY || e.target.value >= MAX_QUANTITY) {
+      return quantityCount;
+    }
     setQuantityCount(e.target.value);
   }
 
   const { name, price, picture } = product;
   return (
-    <div className="productPreview">
-      <div className="productPreview-container">
+    <div className="product-preview">
+      <div className="product-preview-container">
         <div className="image-container">
           <img src={picture} alt={name} />
         </div>
         <div className="info-container">
-          <h3 className="productpreview-plant-name">{name}</h3>
+          <h3 className="product-preview-plant-name">{name}</h3>
           <div className="info-container-stripes">
             <div className="info-container-stripe">
-              <p className="productpreview-texts">2lt pot </p>
-              <p className="productpreview-texts"> DKK {+' ' + price}</p>
+              <p className="product-preview-texts">2lt pot</p>
+              <p className="product-preview-texts"> DKK {+' ' + price}</p>
             </div>
             <div className="info-container-stripe">
-              <p className="productpreview-texts">Quantity</p>
+              <p className="product-preview-texts">Quantity</p>
               <button
                 type="button"
                 className="quantity-button"
@@ -45,7 +57,7 @@ export default function ProductPreview({
                 -
               </button>
               <input
-                className="productpreview-input"
+                className="product-preview-input"
                 type="text"
                 value={quantityCount}
                 onChange={handleQuantityCountChange}

--- a/src/client/components/ProductPreview/ProductPreview.styles.css
+++ b/src/client/components/ProductPreview/ProductPreview.styles.css
@@ -1,4 +1,4 @@
-.productPreview {
+.product-preview {
   width: 100%;
   height: 100%;
   display: flex;
@@ -9,7 +9,7 @@
   color: black;
 }
 
-.productPreview-container {
+.product-preview-container {
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
@@ -24,6 +24,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.image-container img {
+  max-width: 320px;
 }
 
 .info-container {
@@ -52,13 +56,13 @@
   font-size: 1.2rem;
   padding: 0.3rem 1rem;
 }
-.productpreview-plant-name {
+.product-preview-plant-name {
   font-family: Inter;
   color: #687808;
   padding: 0 0 1.8rem 0;
   font-size: 28px;
 }
-.productpreview-texts {
+.product-preview-texts {
   padding-right: 20px;
   font-size: 24px;
   font-weight: 400;
@@ -68,7 +72,7 @@
   letter-spacing: 0em;
   text-align: left;
 }
-.productpreview-input {
+.product-preview-input {
   border: 1px solid #929b90;
 }
 @supports (-webkit-appearance: none) or (-moz-appearance: none) {
@@ -100,7 +104,7 @@
     margin-top: 2rem;
   }
 
-  .productPreview-container {
+  .product-preview-container {
     border: none;
   }
 }


### PR DESCRIPTION
# Description
Fixed ProductPreview component so users cannot enter negative or way to high numbers
while adding products to cart by using the input field or the +/- buttons.

Fixes # (issue)
https://github.com/HackYourFuture-CPH/fp-class19/issues/226

# How to test?
npm run storybook

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
