### PR TITLE
 Feature: Link to ProductPage

### DIFF
--- a/src/client/components/Product/Product.component.js
+++ b/src/client/components/Product/Product.component.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import './Product.styles.css';
 import cartBucketImage from '../../assets/images/cart_bucket.png';
@@ -48,10 +49,16 @@ export default function Product({
   };
   return (
     <div className="product-container">
-      <img className="product-image" src={image} alt={name} />
-
+      <Link to={`/products/${id}`}>
+        <img
+          className="product-image"
+          src={image}
+          alt={name}
+          width={257}
+          height={226}
+        />
+      </Link>
       <h2 className="product-name">{name}</h2>
-
       <h2 className="product-price">
         {price} {currency}
       </h2>

--- a/src/client/components/Product/Product.styles.css
+++ b/src/client/components/Product/Product.styles.css
@@ -8,7 +8,6 @@
   border: 1px solid #c4c4c4;
   margin: 5px;
   height: 397;
-  padding: 10px;
 }
 
 .product-name {
@@ -31,7 +30,6 @@
 
 .product-add-button {
   background: #687808;
-
   color: #fff;
   font-size: 1.6rem;
   font-weight: bolder;
@@ -43,6 +41,7 @@
   font-size: 25px;
   padding-bottom: 5px;
 }
+
 .product-add-button:active {
   background-color: #414b0b;
 }

--- a/src/client/components/SpecialOffers/OfferProductModel.component.js
+++ b/src/client/components/SpecialOffers/OfferProductModel.component.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import './OfferProductModel.styles.css';
 import cartBucketImage from '../../assets/images/cart_bucket.png';
@@ -57,13 +58,15 @@ export default function OfferProduct({
       }}
     >
       <div className="image-and-discount">
-        <img
-          className="offer-product-image"
-          src={image}
-          alt={name}
-          width={257}
-          height={226}
-        />
+        <Link to={`/products/${id}`}>
+          <img
+            className="offer-product-image"
+            src={image}
+            alt={name}
+            width={257}
+            height={226}
+          />
+        </Link>
         <div className="discount-box">
           <h3>{discount}% OFF</h3>
         </div>


### PR DESCRIPTION
# Description
This PR is about giving the users the possibility to go to the ProductPage by clicking on a product image either on the 
landing page or the special offers page.

Fixes # (issue)
https://github.com/HackYourFuture-CPH/fp-class19/issues/240

# How to test?
Try to click on the flower images on landing page and on the special offers page.
If you end up on the ProductPage  ( / products/:id) -> it's working

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
